### PR TITLE
typo for variable player(s); adding settingtypes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -5,24 +5,25 @@ level, max gravity at sea level.
 
 ]]--
 
+local action_timer = 0
+local realgthres=minetest.settings:get('real_g_threshold') or 300
 
-local update = function()
+local gravity_update = function()
 	for _, players in ipairs(minetest.get_connected_players()) do
-	    local pos = player:get_pos()
+	    local pos = players:get_pos()
 	    local grav = 1
-	    if pos.y > 300 then grav = 300/pos.y end
-	    if pos.y < -300 then grav = -300/pos.y end
-	    player:set_physics_override({gravity=grav})
+	    if pos.y > realgthres then grav = realgthres/pos.y end
+	    if pos.y < (-1)*realgthres then grav = -1*realgthres/pos.y end
+	    players:set_physics_override({gravity=grav})
 	end
 end
 
-local action_timer = 0
 
 local function gravity_globaltimer(dtime)
 	action_timer = action_timer + dtime
 
 	if action_timer > 4 then
-		update()
+		gravity_update()
 		action_timer = 0
 	end
 end

--- a/init.lua
+++ b/init.lua
@@ -12,8 +12,7 @@ local gravity_update = function()
 	for _, players in ipairs(minetest.get_connected_players()) do
 	    local pos = players:get_pos()
 	    local grav = 1
-	    if pos.y > realgthres then grav = realgthres/pos.y end
-	    if pos.y < (-1)*realgthres then grav = -1*realgthres/pos.y end
+	    if abs(pos.y) > realgthres then grav = abs(realgthres/pos.y) end
 	    players:set_physics_override({gravity=grav})
 	end
 end

--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,2 @@
+name = real_g
+depends = default

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,1 @@
+real_g_threshold (Threshold for activating real_g) int 300


### PR DESCRIPTION
Mod didn't work at first.
There is a typo. The Player Infos are grabbed into var Players, but in the following Code the variable Player (without s) is used.
Further: a mod.conf and settingtype.txt to adjust the threshold of real_g.